### PR TITLE
patch the non-forwarding overload

### DIFF
--- a/Source/Source/Patches/Pawn_MindState_Patch.cs
+++ b/Source/Source/Patches/Pawn_MindState_Patch.cs
@@ -9,7 +9,7 @@ namespace Hospitality.Patches
     /// </summary>
     public class Pawn_MindState_Patch
     {
-        [HarmonyPatch(typeof(Pawn_MindState), "Reset", new[] { typeof(bool), typeof(bool) })]
+        [HarmonyPatch(typeof(Pawn_MindState), "Reset", new[] { typeof(bool), typeof(bool), typeof(bool) })]
         public static class Pawn_MindState_Reset_Patch
         {
             [HarmonyPostfix]


### PR DESCRIPTION
Presumably the point of the patch is to be called whenever Reset() is called, but if the 3-bool overload is called, the patched code would not be called.

(I'm not aware of any actual problem caused by this, just something I've noticed by chance.)
