### PR TITLE
filter out allowed zones list if TD Enhancement Pack mod is used

### DIFF
--- a/Source/Source/MainTab/AreaGUI.cs
+++ b/Source/Source/MainTab/AreaGUI.cs
@@ -4,6 +4,7 @@ using RimWorld;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
+using Hospitality.Utilities;
 
 namespace Hospitality.MainTab
 {
@@ -20,7 +21,7 @@ namespace Hospitality.MainTab
             int num1 = 1;
             for (int index = 0; index < allAreas.Count; ++index)
             {
-                if (allAreas[index].AssignableAsAllowed())
+                if (allAreas[index].AssignableAsAllowed() && TDPackAreas.IsAllowed(allAreas[index]))
                     ++num1;
             }
 
@@ -31,7 +32,7 @@ namespace Hospitality.MainTab
             int num2 = 1;
             for (int index = 0; index < allAreas.Count; ++index)
             {
-                if (allAreas[index].AssignableAsAllowed())
+                if (allAreas[index].AssignableAsAllowed() && TDPackAreas.IsAllowed(allAreas[index]))
                 {
                     float num3 = num2 * width;
                     DoAreaSelector(new Rect(rect.x + num3, rect.y, width, rect.height), p, allAreas[index], getArea, setArea);

--- a/Source/Source/Utilities/GuestUtility.cs
+++ b/Source/Source/Utilities/GuestUtility.cs
@@ -834,7 +834,7 @@ public static class GuestUtility
 
     public static IEnumerable<Area> GetAreas(Map map)
     {
-        return map.areaManager.AllAreas.Where(a => a.AssignableAsAllowed());
+        return map.areaManager.AllAreas.Where(a => a.AssignableAsAllowed() && TDPackAreas.IsAllowed(a));
     }
 
     // From RimWorld.AreaAllowedGUI, modified

--- a/Source/Source/Utilities/TDPackAreas.cs
+++ b/Source/Source/Utilities/TDPackAreas.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+using RimWorld;
+using Verse;
+using HarmonyLib;
+
+namespace Hospitality.Utilities;
+
+internal static class TDPackAreas
+{
+    // TD Enhancement Pack mod adds various area improvements, including increasing the maximum number of areas,
+    // and marking some as not for colonists/animals/mechs, in order to make the number of areas shown manageable.
+
+    private delegate bool IsForDelegate(Area area);
+    private static IsForDelegate IsForColonists;
+    static TDPackAreas()
+    {
+        MethodInfo func = AccessTools.Method("TD_Enhancement_Pack.MapComponent_AreaOrder:IsForColonists");
+        if(func != null)
+            IsForColonists = (IsForDelegate) Delegate.CreateDelegate(typeof(IsForDelegate), null, func, true);
+    }
+
+    public static bool IsAllowed(Area area)
+    {
+        if(IsForColonists == null)
+            return true; // Always.
+        if(IsForColonists(area))
+            return true;
+        // As a special case, allow also all areas ending with "Hospitality", which allows disabling showing
+        // them for colonists/animals/mechs, so that they do not show up anywhere else. End of the name rather
+        // than the start of the name is so that several of them can be differentiated with the little space
+        // that is available in the UI.
+        if(area.Label.EndsWith("Hospitality"))
+            return true;
+        return false;
+    }
+}


### PR DESCRIPTION
TD Enhancement Pack mod allows disabling showing an area for colonists, animals or mechs, and it's easy to get to 10+ zones that way. Which gets hard to use with Hospitality showing the full list, twice.

So do not show areas disabled for colonists. As a special feature, allow those that have name ending in "Hospitality", so that it's possible to disable showing them everywhere else. That should probably be mentioned somewhere in mod description, so that it's not just a me-only feature.

Requires https://github.com/MemeGoddess/RimWorld-EnhancementPack/pull/12 .
