### PR TITLE
Don't save CompGuest.lord when the lord is already gone

### DIFF
--- a/Source/Source/CompGuest.cs
+++ b/Source/Source/CompGuest.cs
@@ -80,6 +80,12 @@ public class CompGuest : ThingComp
         Scribe_References.Look(ref guestArea_int, "guestArea");
         Scribe_References.Look(ref shoppingArea_int, "shoppingArea");
         Scribe_References.Look(ref bed, "bed");
+        // A lord that is no longer in any map's LordManager will not be saved, so
+        // this reference dangles on load: "Could not resolve reference to object
+        // with loadID Lord_N". Guests that simply visit and leave never clear the
+        // field - only Leave(clearLord: true) does, and only Adopt() passes true -
+        // so a departed guest keeps pointing at a disbanded lord forever.
+        if (Scribe.mode == LoadSaveMode.Saving && lord != null && !Find.Maps.Any(map => map.lordManager.lords.Contains(lord))) lord = null;
         Scribe_References.Look(ref lord, "lord");
         boughtItems ??= [];
 


### PR DESCRIPTION
Loading a save that once had visitors logs this, once per departed guest:

```
Could not resolve reference to object with loadID Lord_1 of type Verse.AI.Group.Lord.
Was it compressed away, destroyed, had no ID number, or not saved/loaded right?
curParent=Bullock
```

`CompGuest.lord` is scribed with `Scribe_References.Look`, but nothing clears it when the visiting group's Lord is disbanded. `Leave(bool clearLord)` is the only place the field is nulled, and of its two call sites only `Adopt()` passes `true`. A group that visits and leaves normally calls neither, so those pawns despawn, become world pawns, and keep `arrived = true` plus a reference to a Lord that no longer exists. `PostDeSpawn` doesn't clear it, and `PostSpawnSetup` only refreshes it on respawn, which a world pawn never does.

The Lord isn't in any `LordManager` any more, so `LordManager.ExposeData` never writes it, and the reference dangles on load. In the save I hit this on, `Lord_1` occurs exactly once in the entire `.rws`: as the dangling reference. `lordManager/lords` is empty. The offending pawn is a `Town_Councilman` with `<becameWorldPawnTickAbs>` set, sitting at `arrived=True` and `lord=Lord_1`.

This PR skips the write when the lord isn't in any map's `LordManager`, which is the same condition that decides whether the Lord gets saved at all. Nothing is lost: for spawned pawns `PostSpawnSetup` already does `lord = Pawn.GetLord()` on every load, so the scribed value is overwritten anyway, and for a despawned pawn the field resolves to `null` on load regardless. The patch just makes it `null` before it becomes an error instead of after.

It iterates `Find.Maps` rather than reading `lord.Map`, because `Lord.Map` is `lordManager.map` and throws on a Lord already detached from its manager, which is exactly the state being tested.

Severity is low and self-draining, so this is cleanup rather than a crash fix: one error per stale guest, and a load-and-re-save clears the existing ones permanently. It recurs on the next visit, which is why the field needs clearing at the source.

Tested in RimWorld 1.6.4871 with Hospitality 3509486825 in a 216-mod list, as a Harmony prefix carrying the same condition, before porting it here:

- Live visit, `VisitorGroup` incident with "Assure safety", saved and reloaded: the 2 visitors kept `Lord_1`, it's in `lordManager`, it resolved, zero errors. The preserve branch does not touch an active visit.
- Same visit run to completion at dev ultrafast until the group left, then saved: `lordManager` empty, 282 `<lord>` refs in the file, 0 non-null, none dangling, and one comp at `arrived=True` with a null lord. That combination can't be produced by `Leave()`, which sets `arrived=false` in the same call, so it's the patch and not something else. Reload was clean.
- On the unpatched game the same save load produced the error quoted above.

Builds clean against the pinned `Krafs.Rimworld.Ref 1.6.4494-beta`, 0 warnings.

Filed as a PR because there's nowhere to file it as an issue: this repo has issues disabled, and OrionFive turned his off after I reported it there (OrionFive/Hospitality#865), noting that he no longer develops the mod and that you don't read that tracker.
